### PR TITLE
Update Perl6.sublime-syntax

### DIFF
--- a/Perl6.sublime-syntax
+++ b/Perl6.sublime-syntax
@@ -4,11 +4,13 @@
 name: Perl6
 file_extensions:
   - [pm6, p6]
+  - [pl, pm, PL, PL6]
+  - t
 scope: source.perl6
-first_line_match: use v6;
+first_line_match: ^#!.*\bperl6\b|^use\s*v6\;.*
 
 variables:
-  identifier: '[\w|\_][\w|\d|-]+[\w|_]'
+  identifier: '[_\p{L}][\p{Nd}\p{L}\''-_]+[\p{Nd}\p{L}]|[_\p{L}][\p{Nd}\p{L}]|[_\p{L}]'
   basic_types: 'Int|Str'
   function_types: 'sub|method'
   data_structure_types: 'class'


### PR DESCRIPTION
- add more extension
- first line also can be shebang

    people may write first line as: `#!/usr/bin/perl6` or `#!perl6` or `#!/usr/bin/env perl6`

- the identifier is support unicode: 
    
    Some reference: 
     https://docs.perl6.org/syntax/%20identifiers 
     https://en.wikipedia.org/wiki/Unicode_character_property#General_Category
     https://www.regular-expressions.info/unicode.html